### PR TITLE
fix: cube.js em produção exigia cluster de Cube Store sem necessidade

### DIFF
--- a/.github/workflows/build-and-deploy-cubejs.yml
+++ b/.github/workflows/build-and-deploy-cubejs.yml
@@ -66,4 +66,4 @@ jobs:
             --project $PROJECT_ID \
             --allow-unauthenticated \
             --service-account sa-observatudo-cubejs@observatudo-infra.iam.gserviceaccount.com \
-            --set-env-vars NODE_ENV=production,CUBEJS_DB_TYPE=bigquery,CUBEJS_DB_BQ_PROJECT_ID=observatudo-infra,CUBEJS_DB_EXPORT_BUCKET=observatudo-infra-www-data,CUBEJS_API_SECRET=${{ secrets.CUBEJS_API_SECRET }}
+            --set-env-vars NODE_ENV=production,CUBEJS_CACHE_AND_QUEUE_DRIVER=memory,CUBEJS_DB_TYPE=bigquery,CUBEJS_DB_BQ_PROJECT_ID=observatudo-infra,CUBEJS_DB_EXPORT_BUCKET=observatudo-infra-www-data,CUBEJS_API_SECRET=${{ secrets.CUBEJS_API_SECRET }}

--- a/docs/external/cubejs.md
+++ b/docs/external/cubejs.md
@@ -97,6 +97,15 @@ servidor sobe mas todo schema falha ao compilar com "Unable to load
 @cubejs-backend/native"; rodar `pnpm install` novamente (ou `npx
 post-installer` dentro de `node_modules/@cubejs-backend/native`) resolve.
 
+Achado em produção (2026-06-22): com `NODE_ENV=production`, o Cube exige
+por padrão um cluster externo de Cube Store (`CUBEJS_CUBESTORE_HOST`/
+`PORT`) pra cache/fila de queries — `/cubejs-api/v1/load` falhava com
+"Cube Store was specified as queue/cache driver". Resolvido com
+`CUBEJS_CACHE_AND_QUEUE_DRIVER=memory`, o driver documentado pra
+deployments single-instance pequenos (nosso caso: 1 serviço Cloud Run,
+sem necessidade de cache distribuído ainda). Reconsiderar se/quando houver
+múltiplas instâncias ou pre-agregações pesadas.
+
 ## Pontos abertos
 
 - **Deploy: self-hosted via Cloud Run — decidido em 2026-06-22**, com a

--- a/infra/cubejs.tf
+++ b/infra/cubejs.tf
@@ -69,6 +69,16 @@ resource "google_cloud_run_service" "cubejs" {
           value = "production"
         }
 
+        # Sem isso, NODE_ENV=production faz o Cube exigir um cluster
+        # externo de Cube Store (CUBEJS_CUBESTORE_HOST/PORT) pra
+        # cache/fila de queries — desproporcional para 1 instância
+        # Cloud Run sem pre-agregação configurada ainda. "memory" é o
+        # driver documentado pra deployments single-instance pequenos.
+        env {
+          name  = "CUBEJS_CACHE_AND_QUEUE_DRIVER"
+          value = "memory"
+        }
+
         env {
           name  = "CUBEJS_DB_TYPE"
           value = "bigquery"


### PR DESCRIPTION
## Summary
- Achado pós-deploy (PR #18 já mergeada e rodando): `NODE_ENV=production` faz o Cube exigir por padrão um cluster externo de Cube Store para cache/fila de queries — `/cubejs-api/v1/load` falhava com `"Cube Store was specified as queue/cache driver"`, confirmado direto no serviço já no ar.
- Fix: `CUBEJS_CACHE_AND_QUEUE_DRIVER=memory`, o driver documentado para deployments single-instance pequenos (nosso caso: 1 serviço Cloud Run, sem pre-agregação configurada ainda).
- Atualizado em `infra/cubejs.tf` (env var declarada) e no workflow de deploy (`--set-env-vars`).

## Test plan
- [x] `terraform validate`
- [ ] Após merge, o workflow redeploya automaticamente (path filter em `apps/api/**`... este PR só toca `infra/`/`.github/workflows/`/`docs/` — vou disparar o deploy manualmente via `workflow_dispatch` ou validar direto no serviço)
- [x] Reproduzido o erro real (`/cubejs-api/v1/load` no serviço em produção antes do fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)