### PR TITLE
fix: expõe indicador_id/localidade_id como public no Cube.js

### DIFF
--- a/apps/api/model/cubes/dim_indicadores.js
+++ b/apps/api/model/cubes/dim_indicadores.js
@@ -6,6 +6,10 @@ cube(`dim_indicadores`, {
       sql: `indicador_id`,
       type: `string`,
       primary_key: true,
+      // Primary keys ficam public:false por padrão — mas o frontend
+      // precisa filtrar/selecionar por indicador_id diretamente (busca,
+      // resolução de nomes), não só usar como chave de join interna.
+      public: true,
     },
     nome: { sql: `nome`, type: `string` },
     descricao: { sql: `descricao`, type: `string` },

--- a/apps/api/model/cubes/dim_localidades.js
+++ b/apps/api/model/cubes/dim_localidades.js
@@ -6,6 +6,9 @@ cube(`dim_localidades`, {
       sql: `localidade_id`,
       type: `string`,
       primary_key: true,
+      // Mesmo motivo do indicador_id em dim_indicadores.js: frontend
+      // precisa filtrar por localidade_id diretamente.
+      public: true,
     },
     nome: { sql: `nome`, type: `string` },
     tipo: { sql: `tipo`, type: `string` },


### PR DESCRIPTION
## Summary
- `primary_key: true` deixa o membro `public: false` por padrão no Cube — mas o frontend precisa filtrar/selecionar `indicador_id`/`localidade_id` diretamente (busca, resolução de nomes, série histórica por localidade), não só usá-los como chave interna de join.
- Achado real durante a migração do frontend pro Cube.js: qualquer query selecionando esses campos falhava com `"You requested hidden member: ... Please make it visible using public: true"`.

## Test plan
- [x] `pnpm --filter api lint` limpo
- [ ] Após merge + deploy, vou validar a query real do frontend (`/api/indicadores/search`) contra produção

🤖 Generated with [Claude Code](https://claude.com/claude-code)