### PR TITLE
feat: migra /api/indicadores/search para Cube.js (Fase 6)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -58,6 +58,9 @@ jobs:
 
       - name: Deploy no Cloud Run
         run: |
+          CUBEJS_API_URL=$(gcloud run services describe cubejs-observatudo \
+            --region $REGION --project $PROJECT_ID --format='value(status.url)')
+
           gcloud run deploy $SERVICE_NAME \
             --image $IMAGE_NAME \
             --region $REGION \
@@ -65,4 +68,4 @@ jobs:
             --project $PROJECT_ID \
             --allow-unauthenticated \
             --service-account sa-observatudo-www-app@observatudo-infra.iam.gserviceaccount.com \
-            --set-env-vars BIGQUERY_PROJECT_ID=observatudo-infra,BIGQUERY_DATASET_ID=gold
+            --set-env-vars BIGQUERY_PROJECT_ID=observatudo-infra,BIGQUERY_DATASET_ID=gold,CUBEJS_API_URL=$CUBEJS_API_URL,CUBEJS_API_SECRET=${{ secrets.CUBEJS_API_SECRET }}

--- a/AI_context/REFACTOR_CONTEXT.md
+++ b/AI_context/REFACTOR_CONTEXT.md
@@ -135,11 +135,15 @@ descrição completa. Resumo:
    mapeando o dataset `gold`. Não inclui ainda migrar o frontend para
    consumi-lo. Depende da Fase 3 (precisa do `gold` materializado e
    estável).
-6. **Migrar o frontend rota a rota** — fechar autenticação/protocolo
-   (`docs/external/cubejs.md`, "Pontos abertos"; deploy self-hosted via
-   Cloud Run já decidido na Fase 5), então substituir
-   `src/app/api/indicadores/*` pelo consumo via Cube.js, um indicador por
-   vez. Depende da Fase 5.
+6. 🔄 **Migrar o frontend rota a rota** — protocolo fechado (proxy
+   server-side, ver Progresso); substituir `src/app/api/indicadores/*`
+   pelo consumo via Cube.js, uma rota por vez, até não restar acesso
+   direto ao BigQuery no frontend. Depende da Fase 5.
+   - ✅ `/api/indicadores/search`
+   - `/api/indicadores/nomeados`
+   - `/api/indicadores/localidade/[municipio_id]` (dashboard principal)
+   - Remover `lib/analytics/client.ts`/`query.ts` e a dependência
+     `@google-cloud/bigquery` do frontend depois das 3 rotas migradas.
 7. **Limpeza** — remover código/infra órfã do estado anterior (rotas de API
    substituídas, dataset `dados` antigo, etc.).
 
@@ -393,10 +397,40 @@ roadmap** — só entra quando houver endpoints concretos a implementar
   `--set-env-vars` no deploy — não usa Secret Manager do GCP, esse
   recurso não foi criado.
 
+- **Fase 6 iniciada em 2026-06-22**: protocolo de consumo do Cube.js no
+  frontend fechado — proxy server-side. As rotas Next.js
+  (`src/app/api/indicadores/*`) continuam com o mesmo contrato pro
+  browser, mas por dentro passam a chamar o Cube.js via
+  `@cubejs-client/core` (`apps/frontend/src/lib/cubejs/client.ts`),
+  autenticando com um JWT assinado a partir de `CUBEJS_API_SECRET` no
+  servidor — o browser nunca vê esse secret nem fala com o Cube.js
+  direto. Evita reabrir a questão de autenticação de usuário (Firebase)
+  no Cube.js por agora. Antes de migrar, removido código morto sem
+  consumidor real (`/api/indicadores` bare, `/api/indicadores/list`,
+  `hooks/useIndicadores.ts`, `hooks/olduseIndicadoresDashboard.ts`,
+  exports não usados em `lib/analytics/dimensions/`+`measures/`) —
+  investigado via histórico do git antes de apagar, confirmado que cada
+  um foi criado para uma feature que não vingou.
+  - `/api/indicadores/search` migrado: `buscarIndicadores()` agora
+    consulta o cubo `dim_indicadores` via Cube.js (filtro `contains`
+    case-insensitive em nome/descrição + `equals` em indicador_id).
+  - Achado real durante a migração: `primary_key: true` deixa o membro
+    `public: false` por padrão no Cube — `indicador_id`/`localidade_id`
+    precisaram de `public: true` explícito em `apps/api/model/cubes/
+    {dim_indicadores,dim_localidades}.js` pro frontend conseguir
+    filtrar/selecionar por eles diretamente (não só usar como chave de
+    join interna).
+  - `infra/main.tf`: serviço Cloud Run do frontend ganhou `CUBEJS_API_URL`
+    (referência dinâmica ao serviço do Cube.js, não hardcoded) e
+    `CUBEJS_API_SECRET`; `.github/workflows/build-and-deploy.yml`
+    resolve a URL real via `gcloud run services describe` no deploy.
+  - **Cuidado registrado**: `var.cubejs_image_url` tinha um default
+    público (`cubejs/cube:latest`) que, se aplicado depois do CI já ter
+    publicado a imagem real, reverteria o deploy — default removido
+    (var agora obrigatória, mesmo padrão de `var.image_url`).
+
 ## Decisões abertas (bloqueiam issues downstream)
 
-- Autenticação e protocolo de consumo do Cube.js no frontend (deploy já
-  decidido: self-hosted via Cloud Run) — ver `docs/external/cubejs.md`.
 - **`run.invoker` do Cube.js está `allUsers`** (mesmo padrão do frontend,
   decisão consciente de manter assim por ora em 2026-06-22) — qualquer
   requisição chega no container (mesmo que rejeitada depois pelo

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -4,6 +4,11 @@ BIGQUERY_DATASET_ID=seu-dataset-id
 BIGQUERY_KEYFILE=./path/to/keyfile.json
 BIGQUERY_REGION=
 
+# Cube.js (apps/api) — uso server-side só nas rotas de API, nunca exposto
+# ao browser. CUBEJS_API_URL é a base do serviço (sem /cubejs-api/v1).
+CUBEJS_API_URL=http://localhost:4000
+CUBEJS_API_SECRET=changeme-local-dev-secret
+
 # Configuração mínima do Firebase para autenticação
 NEXT_PUBLIC_FIREBASE_API_KEY=your-api-key
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@cubejs-client/core": "^1.6.60",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
@@ -16,6 +17,7 @@
     "@ducanh2912/next-pwa": "^10.2.9",
     "@google-cloud/bigquery": "^8.0.0",
     "firebase": "^11.8.1",
+    "jsonwebtoken": "^9.0.3",
     "lucide-react": "^0.512.0",
     "next": "15.3.2",
     "react": "^19.0.0",
@@ -26,6 +28,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/apps/frontend/src/lib/analytics/indicadores.ts
+++ b/apps/frontend/src/lib/analytics/indicadores.ts
@@ -1,21 +1,37 @@
 //src/lib/analytics/indicadores.ts
 import { QueryBuilder } from "./query";
+import { cubejsApi } from "@/lib/cubejs/client";
 import type { Indicador } from '@/types';
 
-export async function buscarIndicadores(query: string): Promise<Indicador[]> {
-  const lowerQuery = query.toLowerCase();
-  const qb = new QueryBuilder("dim_indicadores")
-    .addDimension({ name: "id", sql: "indicador_id", type: "string" })
-    .addDimension({ name: "nome", sql: "nome", type: "string" })
-    .addDimension({ name: "descricao", sql: "descricao", type: "string" })
-    .orWhereRaw(`
-      LOWER(nome) LIKE '%${lowerQuery}%'
-      OR LOWER(descricao) LIKE '%${lowerQuery}%'
-      OR LOWER(indicador_id) = '${lowerQuery}'
-    `)
-    .limit(20);
+export async function buscarIndicadores(
+  query: string
+): Promise<Pick<Indicador, "id" | "nome" | "descricao">[]> {
+  const resultSet = await cubejsApi.load({
+    dimensions: [
+      "dim_indicadores.indicador_id",
+      "dim_indicadores.nome",
+      "dim_indicadores.descricao",
+    ],
+    filters: [
+      {
+        or: [
+          { member: "dim_indicadores.nome", operator: "contains", values: [query] },
+          { member: "dim_indicadores.descricao", operator: "contains", values: [query] },
+          { member: "dim_indicadores.indicador_id", operator: "equals", values: [query] },
+        ],
+      },
+    ],
+    limit: 20,
+  });
 
-  return qb.execute<Indicador>();
+  return resultSet.rawData().map((row) => ({
+    id: String(row["dim_indicadores.indicador_id"]),
+    nome: String(row["dim_indicadores.nome"] ?? ""),
+    descricao:
+      row["dim_indicadores.descricao"] != null
+        ? String(row["dim_indicadores.descricao"])
+        : undefined,
+  }));
 }
 
 

--- a/apps/frontend/src/lib/cubejs/client.ts
+++ b/apps/frontend/src/lib/cubejs/client.ts
@@ -1,0 +1,22 @@
+// src/lib/cubejs/client.ts
+//
+// ⚠️ Uso estritamente server-side (rotas de API): assina o JWT com
+// CUBEJS_API_SECRET, que nunca deve chegar ao browser.
+
+import cubejs from "@cubejs-client/core";
+import jwt from "jsonwebtoken";
+
+const apiUrl = process.env.CUBEJS_API_URL ?? "";
+const apiSecret = process.env.CUBEJS_API_SECRET ?? "";
+
+// Falha só no momento real de uso (assinatura do JWT), não na carga do
+// módulo — mesma convenção de lib/analytics/client.ts (que também só
+// resolve as envs em runtime, não no import), pra não quebrar o build
+// caso as envs não estejam presentes nesse momento.
+async function gerarToken(): Promise<string> {
+  return jwt.sign({}, apiSecret, { expiresIn: "1h" });
+}
+
+export const cubejsApi = cubejs(gerarToken, {
+  apiUrl: `${apiUrl}/cubejs-api/v1`,
+});

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -42,6 +42,20 @@ resource "google_cloud_run_service" "www_observatudo" {
           name  = "BIGQUERY_DATASET_ID"
           value = var.bigquery_dataset_id
         }
+
+        # Cube.js (apps/api) — uso server-side só nas rotas de API, ver
+        # apps/frontend/src/lib/cubejs/client.ts. URL real do serviço
+        # (não hardcoded) para não desincronizar se o Cloud Run do
+        # Cube.js for recriado.
+        env {
+          name  = "CUBEJS_API_URL"
+          value = google_cloud_run_service.cubejs.status[0].url
+        }
+
+        env {
+          name  = "CUBEJS_API_SECRET"
+          value = var.cubejs_api_secret
+        }
       }
     }
   }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -16,8 +16,7 @@ variable "image_url" {
 
 variable "cubejs_image_url" {
   type        = string
-  default     = "cubejs/cube:latest"
-  description = "URL da imagem Docker do Cube.js. Bootstrap usa a imagem pública oficial; CI publica a imagem real (com model/ embutido) e passa essa var no apply seguinte."
+  description = "URL da imagem Docker do Cube.js publicada pelo CI (gcr.io/observatudo-infra/observatudo-cubejs). Sem default: usar o placeholder público (cubejs/cube:latest) por engano aqui reverte o deploy real feito pelo CI (já aconteceu uma vez)."
 }
 
 variable "cubejs_api_secret" {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
 
   apps/frontend:
     dependencies:
+      '@cubejs-client/core':
+        specifier: ^1.6.60
+        version: 1.6.60
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -50,6 +53,9 @@ importers:
       firebase:
         specifier: ^11.8.1
         version: 11.10.0
+      jsonwebtoken:
+        specifier: ^9.0.3
+        version: 9.0.3
       lucide-react:
         specifier: ^0.512.0
         version: 0.512.0(react@19.2.7)
@@ -75,6 +81,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.3.1
+      '@types/jsonwebtoken':
+        specifier: ^9.0.10
+        version: 9.0.10
       '@types/node':
         specifier: ^20
         version: 20.19.43
@@ -857,6 +866,9 @@ packages:
   '@cubejs-backend/templates@1.6.60':
     resolution: {integrity: sha512-yEty0P8JcF727KbsNPSN1rMyI0wGg/7d4hM3U4RC/pzf8w8Wrmt1qlKsTfpJwfncuzh2fpLsj+jsIa3i9/tFdQ==}
     engines: {node: ^14.0.0 || ^16.0.0 || >=17.0.0}
+
+  '@cubejs-client/core@1.6.60':
+    resolution: {integrity: sha512-32qJoJy70hY0evS+QRMNka7sVCX88+SeB0CeiX3+s3Ucq/aXuBLuvPjXD0AnXTTbl3eOXwfo3tlDR9trddVVpg==}
 
   '@cubejs-infra/post-installer@0.0.7':
     resolution: {integrity: sha512-9P2cY8V0mqH+FvzVM/Z43fJmuKisln4xKjZaoQi1gLygNX0wooWzGcehibqBOkeKVMg31JBRaAQrxltIaa2rYA==}
@@ -1871,6 +1883,12 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@20.19.43':
     resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
@@ -2566,6 +2584,9 @@ packages:
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -2576,6 +2597,9 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2591,6 +2615,22 @@ packages:
   csv-write-stream@2.0.0:
     resolution: {integrity: sha512-QTraH6FOYfM5f+YGwx71hW1nR9ZjlWri67/D4CWtiBkdce0UAa91Vc0yyHg0CjC0NeEGnvO/tBSJkA1XF9D9GQ==}
     hasBin: true
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
 
   d@1.0.2:
     resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
@@ -3455,6 +3495,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   interpret@1.4.0:
     resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
@@ -4947,6 +4991,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  url-search-params-polyfill@7.0.1:
+    resolution: {integrity: sha512-bAw7L2E+jn9XHG5P9zrPnHdO0yJub4U+yXJOdpcpkr7OBd9T8oll4lUos0iSGRcDvfZoLUKfx9a6aNmIhJ4+mQ==}
+
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
@@ -4958,6 +5005,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -6540,6 +6591,19 @@ snapshots:
       - moment
       - supports-color
 
+  '@cubejs-client/core@1.6.60':
+    dependencies:
+      core-js: 3.49.0
+      cross-fetch: 3.2.0
+      d3-format: 3.1.2
+      d3-time-format: 4.1.0
+      dayjs: 1.11.21
+      ramda: 0.27.2
+      url-search-params-polyfill: 7.0.1
+      uuid: 11.1.1
+    transitivePeerDependencies:
+      - encoding
+
   '@cubejs-infra/post-installer@0.0.7(moment@2.30.1)':
     dependencies:
       '@cubejs-backend/shared': 0.33.20(moment@2.30.1)
@@ -7722,6 +7786,13 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 20.19.43
+
+  '@types/ms@2.1.0': {}
+
   '@types/node@20.19.43':
     dependencies:
       undici-types: 6.21.0
@@ -8448,6 +8519,8 @@ snapshots:
     dependencies:
       browserslist: 4.28.2
 
+  core-js@3.49.0: {}
+
   core-util-is@1.0.3: {}
 
   cors@2.8.6:
@@ -8458,6 +8531,12 @@ snapshots:
   cron-parser@4.9.0:
     dependencies:
       luxon: 3.7.2
+
+  cross-fetch@3.2.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   cross-spawn@7.0.6:
     dependencies:
@@ -8474,6 +8553,20 @@ snapshots:
       argparse: 1.0.10
       generate-object-property: 1.2.0
       ndjson: 1.5.0
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-format@3.1.2: {}
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
 
   d@1.0.2:
     dependencies:
@@ -9646,6 +9739,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.4
       side-channel: 1.1.1
+
+  internmap@2.0.3: {}
 
   interpret@1.4.0: {}
 
@@ -11177,6 +11272,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url-search-params-polyfill@7.0.1: {}
+
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -11184,6 +11281,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@11.1.1: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
## Summary
Empilhado em cima do #21 (remove código morto) — base dessa PR é `chore/remove-dead-indicadores-routes`, não `main`. Quando o #21 mergear, o diff aqui encolhe pro que é só desta PR.

- Fecha o protocolo de consumo do Cube.js no frontend: **proxy server-side**. As rotas Next.js mantêm o mesmo contrato pro browser, mas por dentro chamam o Cube.js via `@cubejs-client/core` (`lib/cubejs/client.ts`), autenticando com JWT assinado a partir de `CUBEJS_API_SECRET` no servidor. Browser nunca vê o secret nem fala com o Cube.js direto.
- `buscarIndicadores()` (rota `/api/indicadores/search`) migrada — validado contra produção.
- Achado real: `primary_key: true` deixa o membro oculto por padrão no Cube — precisou de `public: true` explícito em `indicador_id`/`localidade_id` (já corrigido e deployado via #22, mergeada).
- `infra/main.tf`: Cloud Run do frontend ganha `CUBEJS_API_URL` (dinâmico) + `CUBEJS_API_SECRET`. **Já aplicado em produção** (0 add, 2 change, 0 destroy).
- `cubejs_image_url` perdeu o default público — aplicar com esse default depois do CI já ter publicado a imagem real reverteria o deploy (quase aconteceu agora, corrigido antes do apply).

## Test plan
- [x] `pnpm --filter frontend build` limpo
- [x] Testado contra produção: `curl /api/indicadores/search?query=mortalidade` → 200, dados reais
- [x] Testado match exato por id (`?query=capag`) → 200
- [x] `terraform plan`/`apply` revisado antes de aplicar (sem destroy, imagem do cubejs confirmada intacta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)