### PR TITLE
feat: migra /api/indicadores/nomeados para Cube.js (Fase 6)

### DIFF
--- a/AI_context/REFACTOR_CONTEXT.md
+++ b/AI_context/REFACTOR_CONTEXT.md
@@ -140,7 +140,7 @@ descrição completa. Resumo:
    pelo consumo via Cube.js, uma rota por vez, até não restar acesso
    direto ao BigQuery no frontend. Depende da Fase 5.
    - ✅ `/api/indicadores/search`
-   - `/api/indicadores/nomeados`
+   - ✅ `/api/indicadores/nomeados`
    - `/api/indicadores/localidade/[municipio_id]` (dashboard principal)
    - Remover `lib/analytics/client.ts`/`query.ts` e a dependência
      `@google-cloud/bigquery` do frontend depois das 3 rotas migradas.
@@ -414,6 +414,9 @@ roadmap** — só entra quando houver endpoints concretos a implementar
   - `/api/indicadores/search` migrado: `buscarIndicadores()` agora
     consulta o cubo `dim_indicadores` via Cube.js (filtro `contains`
     case-insensitive em nome/descrição + `equals` em indicador_id).
+  - `/api/indicadores/nomeados` migrado: `nomesIndicadores()` consulta
+    `dim_indicadores` via Cube.js (`equals` com múltiplos valores =
+    semântica de IN). Validado contra produção.
   - Achado real durante a migração: `primary_key: true` deixa o membro
     `public: false` por padrão no Cube — `indicador_id`/`localidade_id`
     precisaram de `public: true` explícito em `apps/api/model/cubes/

--- a/apps/frontend/src/lib/analytics/indicadores.ts
+++ b/apps/frontend/src/lib/analytics/indicadores.ts
@@ -1,5 +1,4 @@
 //src/lib/analytics/indicadores.ts
-import { QueryBuilder } from "./query";
 import { cubejsApi } from "@/lib/cubejs/client";
 import type { Indicador } from '@/types';
 
@@ -35,16 +34,21 @@ export async function buscarIndicadores(
 }
 
 
-export async function nomesIndicadores(ids: string[]): Promise<Indicador[]> {
-  const qb = new QueryBuilder("dim_indicadores", "i")
-    .addDimension({ name: "id", sql: "i.indicador_id", type: "string" })
-    .addDimension({ name: "nome", sql: "i.nome", type: "string" })
-    .filter({
-      dimension: "i.indicador_id",
-      operator: "IN",
-      values: ids,
-    });
+export async function nomesIndicadores(
+  ids: string[]
+): Promise<Pick<Indicador, "id" | "nome">[]> {
+  if (ids.length === 0) return [];
 
-  return qb.execute<Indicador>();
+  const resultSet = await cubejsApi.load({
+    dimensions: ["dim_indicadores.indicador_id", "dim_indicadores.nome"],
+    filters: [
+      { member: "dim_indicadores.indicador_id", operator: "equals", values: ids },
+    ],
+  });
+
+  return resultSet.rawData().map((row) => ({
+    id: String(row["dim_indicadores.indicador_id"]),
+    nome: String(row["dim_indicadores.nome"] ?? ""),
+  }));
 }
 


### PR DESCRIPTION
## Summary
- `nomesIndicadores()` (rota `/api/indicadores/nomeados`) migrada: consulta `dim_indicadores` via Cube.js em vez do `BigQueryClient`/`QueryBuilder` direto.
- Operador `equals` com múltiplos `values` replica a semântica de `IN` do `QueryBuilder` original.

## Test plan
- [x] `pnpm --filter frontend build` limpo
- [x] Testado contra produção (Cube.js): `POST /api/indicadores/nomeados` com lista de ids → 200, nomes corretos
- [x] Testado com lista vazia → 200, `[]` (sem round-trip ao Cube.js)

🤖 Generated with [Claude Code](https://claude.com/claude-code)