### PR TITLE
fix: índice CAPAG agregado usa nota oficial (A/B/C/D), não média sintética

### DIFF
--- a/AI_context/REFACTOR_CONTEXT.md
+++ b/AI_context/REFACTOR_CONTEXT.md
@@ -518,17 +518,41 @@ melhor que antes, mas não 100% resolvida ainda.
   via `StaleWhileRevalidate` (`maxAgeSeconds: 3600`) — quem já tinha o
   site aberto via service worker continuou vendo a resposta de **antes**
   da migração por até 1h (CAPAG ausente, datas erradas, nomes
-  "Indicador N"). Confirmado via `curl` direto que a API real já está
-  correta (CAPAG aparece com `unidade: "%"`, datas tipo `"2010"` válidas)
-  — o problema observado era cache do navegador/SW, não bug do servidor.
-  Pra testar sem esse cache: aba anônima, ou DevTools → Application →
-  Service Workers → Unregister + Clear storage.
+  "Indicador N"). Confirmado via `curl` direto que a API real já estava
+  correta (CAPAG aparecia com `unidade: "%"` — esse valor em si foi
+  corrigido depois, ver abaixo; datas tipo `"2010"` válidas) — o problema
+  observado era cache do navegador/SW, não bug do servidor. Pra testar
+  sem esse cache: aba anônima, ou DevTools → Application → Service
+  Workers → Unregister + Clear storage.
 - Achado real e separado (não é cache, confirmado direto na API):
   indicadores `144` e `4030` (configurados em
   `data/categoriasIndicadores.ts`, subeixo Finanças) não têm **nenhum**
   dado, nem no município — `serie: []` mesmo pedindo direto. Não se sabe
   ainda se são IDs órfãos (nunca tiveram dado de origem) ou se há algum
   problema de mapeamento; não investigado.
+
+**Correção em 2026-06-22 (achado do usuário a partir do mesmo
+screenshot)**: o "Índice CAPAG Agregado" estava sendo calculado como
+`avg(valor)` dos 3 componentes (Endividamento, Poupança Corrente,
+Liquidez) e exibido com `unidade: '%'` — **não é a nota oficial** do
+Tesouro Nacional. A nota agregada real (`CAPAG - Nota Final`) é
+categórica (A/B/C/D), `valor` é sempre `null` na origem.
+- `silver/capag_agregado.sql` reescrito: seleciona direto
+  `CAPAG - Nota Final` (confirmado 1 linha por localidade+ano, sem
+  agregação necessária) em vez de fazer média dos outros 3
+  componentes; `valor` fica `null` de propósito, `nota` carrega a
+  classificação real.
+- `dim_indicadores.sql`: `unidade` volta a `null` (era `'%'`,
+  incorreto); `descricao` corrigida.
+- `apps/api/model/views/indicadores.js`: `nota` adicionada aos membros
+  expostos de `fact_indicadores` na view (não estava lá).
+- Frontend: `ValorSerie`/`PontoSerieIndicador` ganham campo `nota`;
+  `MetricCard` mostra a nota no lugar do valor numérico quando ela
+  existe (e considera `temDados` mesmo sem `valor`, só com `nota`).
+- Validado contra produção: Salvador (`2927408`) retorna
+  `{"valor": null, "nota": "B"}` pro CAPAG — confirmado via `curl`
+  direto no Cube.js e via `/api/indicadores/localidade/2927408` local
+  apontando pra produção.
 
 ## Ideias para o futuro (não são tarefas — anotadas para quando for retomar)
 

--- a/apps/api/model/views/indicadores.js
+++ b/apps/api/model/views/indicadores.js
@@ -13,6 +13,9 @@ view(`indicadores`, {
         `valor_medio`,
         `valor_minimo`,
         `valor_maximo`,
+        // Classificação categórica (ex.: nota CAPAG A/B/C/D) — alguns
+        // indicadores não têm valor numérico, só essa nota.
+        `nota`,
       ],
     },
     {

--- a/apps/datawarehouse/sql/gold/dim_indicadores.sql
+++ b/apps/datawarehouse/sql/gold/dim_indicadores.sql
@@ -33,7 +33,7 @@ with source as (
   select
       indicador_id,
       'Índice CAPAG Agregado' as nome,
-      'Nota média de sustentabilidade fiscal com base nos três componentes: Endividamento, Poupança Corrente e Liquidez.' as descricao,
+      'Nota oficial de Capacidade de Pagamento (CAPAG) do Tesouro Nacional — classificação A/B/C/D combinando os três componentes (Endividamento, Poupança Corrente e Liquidez). Ver coluna `nota` em fact_indicadores; `valor` não se aplica (classificação categórica, não numérica).' as descricao,
       null as eixo,
       'Finanças' as eixo_ia,
       null as formula,
@@ -41,11 +41,8 @@ with source as (
       null as numero_ods,
       null as nome_ods,
       fonte,
-      -- Média dos três componentes (Endividamento, Poupança Corrente,
-      -- Liquidez), que são razões expressas em percentual na metodologia
-      -- do Tesouro Nacional (Nota Final não entra na média: seu `valor` é
-      -- sempre null na origem).
-      '%' as unidade,
+      -- Classificação categórica (A/B/C/D), não tem unidade numérica.
+      cast(null as string) as unidade,
       'anual' as periodicidade
   from `silver.capag_agregado`
 )

--- a/apps/datawarehouse/sql/silver/capag_agregado.sql
+++ b/apps/datawarehouse/sql/silver/capag_agregado.sql
@@ -1,24 +1,20 @@
 -- sql/silver/capag_agregado.sql
 -- Equivalente a dbt/observatudo/models/intermediate/int_capag.sql (sem dbt).
--- Agrega os 4 componentes do CAPAG (Endividamento, Poupança Corrente,
--- Liquidez, Nota Final) num indicador único por localidade/ano.
+-- "Índice CAPAG Agregado" = a nota oficial do Tesouro Nacional
+-- (CAPAG - Nota Final), não uma média dos 3 componentes — essa nota é
+-- categórica (A/B/C/D), por isso `valor` fica null aqui (não tem
+-- correspondente numérico real; usar `nota` para exibir/filtrar).
 
 select
   localidade_id,
   ano,
   "capag" as indicador_id,
-  avg(cast(valor as float64)) as valor,
-  CAST(any_value(data_referencia) AS DATE) as data_referencia,
-  any_value(fonte) as fonte,
+  cast(null as float64) as valor,
+  CAST(data_referencia AS DATE) as data_referencia,
+  fonte,
   "a > b > c" as direcionalidade,
-  any_value(nota) as nota,
-  any_value(esfera_poder) as esfera_poder
+  nota,
+  esfera_poder
 from `silver.capag`
-where indicador_id in (
-  'CAPAG - Endividamento',
-  'CAPAG - Poupança Corrente',
-  'CAPAG - Liquidez',
-  'CAPAG - Nota Final'
-)
+where indicador_id = 'CAPAG - Nota Final'
 and SAFE_CAST(localidade_id AS INT64) IS NOT NULL
-group by localidade_id, ano

--- a/apps/frontend/src/components/MetricCard/MetricCard.tsx
+++ b/apps/frontend/src/components/MetricCard/MetricCard.tsx
@@ -21,7 +21,12 @@ export const MetricCard: React.FC<MetricCardProps> = ({
   onClick,
 }) => {
   const dados = useMemo(() => {
-    const serie = indicador.serie.filter(p => p.valor !== null && p.valor !== undefined);
+    // Alguns indicadores (ex.: nota CAPAG) só têm classificação
+    // categórica (`nota`), sem valor numérico — também contam como
+    // "tem dado".
+    const serie = indicador.serie.filter(
+      p => (p.valor !== null && p.valor !== undefined) || (p.nota != null && p.nota !== "")
+    );
     const ultimaMedida = serie.at(-1);
     const penultimaMedida = serie.at(-2);
     const serieRecentes = serie.slice(-5);
@@ -133,8 +138,8 @@ export const MetricCard: React.FC<MetricCardProps> = ({
             {showTrend && getTrendIcon()}
             <div className="text-right">
               <div className="text-lg font-bold text-gray-900">
-                {formatarValor(dados.ultimaMedida?.valor)}
-                {indicador.unidade && (
+                {dados.ultimaMedida?.nota ?? formatarValor(dados.ultimaMedida?.valor)}
+                {!dados.ultimaMedida?.nota && indicador.unidade && (
                   <span className="text-xs ml-1 text-gray-500 font-normal">
                     {indicador.unidade}
                   </span>
@@ -175,8 +180,8 @@ export const MetricCard: React.FC<MetricCardProps> = ({
         {/* Valor principal */}
         <div className="text-right ml-4">
           <div className="text-2xl font-bold text-gray-900 mb-1">
-            {formatarValor(dados.ultimaMedida?.valor)}
-            {indicador.unidade && (
+            {dados.ultimaMedida?.nota ?? formatarValor(dados.ultimaMedida?.valor)}
+            {!dados.ultimaMedida?.nota && indicador.unidade && (
               <span className="text-sm ml-2 text-gray-600 font-normal">
                 {indicador.unidade}
               </span>
@@ -216,7 +221,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
               >
                 <span className="text-gray-600">{formatarData(ponto.data)}</span>
                 <span className="font-medium text-gray-900">
-                  {formatarValor(ponto.valor)}
+                  {ponto.nota ?? formatarValor(ponto.valor)}
                 </span>
               </div>
             ))}

--- a/apps/frontend/src/lib/analytics/models/indicadorCivico.ts
+++ b/apps/frontend/src/lib/analytics/models/indicadorCivico.ts
@@ -10,6 +10,8 @@ export interface PontoSerieIndicador {
   fonte: string;
   data: string;
   valor: number | null;
+  // Classificação categórica (ex.: nota CAPAG) — ver ValorSerie.nota.
+  nota: string | null;
 }
 
 export class IndicadorCivico {
@@ -36,6 +38,7 @@ export class IndicadorCivico {
         "indicadores.fonte",
         "indicadores.dim_localidades_localidade_id",
         "indicadores.ano",
+        "indicadores.nota",
       ],
       measures: ["indicadores.valor_medio"],
       filters: [
@@ -79,6 +82,8 @@ export class IndicadorCivico {
         row["indicadores.valor_medio"] != null
           ? Number(row["indicadores.valor_medio"])
           : null,
+      nota:
+        row["indicadores.nota"] != null ? String(row["indicadores.nota"]) : null,
     }));
   }
 }

--- a/apps/frontend/src/services/fetchIndicadores.ts
+++ b/apps/frontend/src/services/fetchIndicadores.ts
@@ -14,6 +14,7 @@ import type {
 interface RawSeriePonto {
   data?: unknown;
   valor?: unknown;
+  nota?: unknown;
 }
 
 interface RawIndicador {
@@ -46,6 +47,7 @@ function sanitizeIndicador(raw: RawIndicador): Indicador {
       ? raw.serie.map((p: RawSeriePonto) => ({
           data: typeof p?.data === "string" ? p.data : "",
           valor: typeof p?.valor === "number" ? p.valor : null,
+          nota: typeof p?.nota === "string" ? p.nota : null,
         }))
       : [],
   };

--- a/apps/frontend/src/services/indicadores.ts
+++ b/apps/frontend/src/services/indicadores.ts
@@ -68,7 +68,7 @@ export async function getLocalidadeFullPorSubeixos(
           nome: primeiro?.indicadorNome ?? `Indicador ${indicadorId}`,
           unidade: primeiro?.unidade ?? "",
           fonte: primeiro?.fonte ?? "",
-          serie: serie.map((p) => ({ data: p.data, valor: p.valor })),
+          serie: serie.map((p) => ({ data: p.data, valor: p.valor, nota: p.nota })),
         };
       }),
     }));

--- a/apps/frontend/src/types/indicadores-model.ts
+++ b/apps/frontend/src/types/indicadores-model.ts
@@ -6,6 +6,9 @@ import type { Localidade } from '@/types';
 export interface ValorSerie {
   data: string; // "2022-01-01" ou apenas ano, se preferir
   valor: number | null;
+  // Classificação categórica (ex.: nota CAPAG "A"/"B"/"C"/"D") — alguns
+  // indicadores não têm valor numérico, só essa nota.
+  nota?: string | null;
 }
 
 export interface Indicador {


### PR DESCRIPTION
## Summary
Achado do usuário a partir de um screenshot real do dashboard: o "Índice CAPAG Agregado" estava sendo calculado como `avg(valor)` dos 3 componentes (Endividamento, Poupança Corrente, Liquidez) e exibido com `unidade: '%'` — **não é a nota oficial** do Tesouro Nacional. Confirmado direto na fonte (`raw.raw_capag`): a nota agregada real (`CAPAG - Nota Final`) é categórica (A/B/C/D), `valor` é sempre `null` na origem.

Toca as 3 camadas (decisão do usuário: corrigir de verdade, não só o rótulo):

1. **Pipeline**: `silver/capag_agregado.sql` reescrito pra selecionar direto `CAPAG - Nota Final` (1 linha por localidade+ano, sem agregação necessária) em vez de média dos outros 3 componentes. `dim_indicadores.sql`: `unidade` volta a `null`, `descricao` corrigida.
2. **Cube.js**: `nota` adicionada aos membros expostos da view `indicadores` (não estava lá).
3. **Frontend**: `ValorSerie`/`PontoSerieIndicador` ganham campo `nota`; `MetricCard` mostra a nota no lugar do valor numérico quando ela existe, e considera `temDados` mesmo só com `nota` (sem isso o card mostraria "Sem dados disponíveis" pra todo indicador categórico).

## Test plan
- [x] `uv run ruff check .` / `uv run pytest` limpos
- [x] Pipeline reexecutado (`silver` + `gold`), validado direto no BigQuery: Salvador tem `nota='B'` real
- [x] `pnpm --filter api lint` limpo
- [x] Cube.js redeployado a partir desta branch via `workflow_dispatch` (antes do merge, pra poder testar) — confirmado `indicadores.nota` retornando `"B"` pra Salvador via `curl` direto
- [x] `pnpm --filter frontend build`/`lint` limpos
- [x] Testado local apontando pra produção: `/api/indicadores/localidade/2927408` retorna `{"valor": null, "nota": "B"}` pro CAPAG

🤖 Generated with [Claude Code](https://claude.com/claude-code)